### PR TITLE
Handle nginx sites enabled, create network, remove network host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ ADD nginx.proxy.conf /etc/nginx/sites-available/
 RUN rm /etc/nginx/sites-enabled/default
 RUN rm /etc/nginx/sites-available/default
 
-# Make Symbolic link to enable the site
-RUN ln -s /etc/nginx/sites-available/* /etc/nginx/sites-enabled/
+# Make Symbolic link to enable the docker example site
+RUN ln -s /etc/nginx/sites-available/nginx.proxy.conf /etc/nginx/sites-enabled/
 
 # Append "daemon off;" to the configuration file
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf

--- a/commands/proxy-nginx
+++ b/commands/proxy-nginx
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Defaults
+UP=1
+PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+PROXY_PATH="${PARENT_PATH/commands/}"
+PROXY_SITES_PATH="${PROXY_PATH}sites.yml"
+
+# P switch for port
+P=$(sed -e 's#.*\-p=\([^\-]*\).*#\1#' <<< "$1$2")
+# D switch for "site down"
+D=$(sed -e 's#.*\-d=\([^\-]*\).*#\1#' <<< "$1$2")
+
+if [ "$P" == "" ]; then 
+    printf "Must specify a port: ./proxy-nginx -p=3000\n"
+    exit
+fi
+
+if [ ! "$P" == "$1$2" ]; then
+    WEB_PORT=$P
+fi
+
+if [ ! "$D" == "$1$2" ]; then
+    UP=0
+fi
+
+SITE=$(eval cat $PROXY_SITES_PATH | awk "/${WEB_PORT}:/"' { print $2 }')
+
+if [ "$SITE" == '' ]; then
+    printf "${WEB_PORT} was not found in ProxyLocal/sites.yml\n";
+    exit;
+fi
+
+CONF="nginx.${SITE}.conf"
+NGINX_COMMAND="ln -s /etc/nginx/sites-available/${CONF} /etc/nginx/sites-enabled/"
+
+if [ "$UP" = 0 ]; then
+    NGINX_COMMAND="rm -f /etc/nginx/sites-enabled/${CONF}"
+fi
+
+printf "${NGINX_COMMAND}\n"
+sudo docker exec proxylocal_proxy_1 bash -c "${NGINX_COMMAND} && service nginx reload"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,10 @@ services:
             - ../:/var/www/site
         ports:
             - "0.0.0.0:80:80"
-        network_mode: "host"
+        expose: 
+            - "80"
+        networks:
+            - docker-proxy-net
+networks:
+  docker-proxy-net:
+    driver: bridge

--- a/nginx.site.conf
+++ b/nginx.site.conf
@@ -5,8 +5,7 @@ server {
     error_log  /var/www/site/ProxyLocal/logs/error.log warn;
 
     location / {
-
-	proxy_pass         http://0.0.0.0:PORT;
+	proxy_pass         http://dockerlocalPORT_web_1;
 	proxy_redirect     off;
 	proxy_set_header   Host $host;
 	proxy_set_header   X-Real-IP $remote_addr;


### PR DESCRIPTION
- no longer use network_mode: host which doesn't work on macs (linux vm is "invisible" but still present) 
- create a network instead
- manage enabling and disabling nginx sites via symbolic links in the new `./proxy-nginx` command
- `./proxy-nginx -p=3000 -d=true` (removes link for site assigned 3000)
- `./proxy-nginx -p=3000` (adds link for site assigned 3000)