### PR TITLE
Update SSL cert generation to be less browser-hated & added error catch

### DIFF
--- a/commands/proxy-sites
+++ b/commands/proxy-sites
@@ -82,10 +82,23 @@ if [ "$SSL" ]; then
     for i in "${!SITES[@]}"
     do
       [ $i -eq 80 ] && continue
-      
+
       # Now create ssl certs for each site
-      openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 -nodes -subj "/CN=${SITES[$i]}" 2>/dev/null
-      
+      openssl req -x509 -keyout key.pem -out cert.pem -sha256 \
+        -days 365 -nodes \
+        -newkey rsa:2048 \
+        -subj "/CN=${SITES[$i]}" \
+        -extensions EXT \
+        -config <(\
+          printf "[dn]\nCN=${SITES[$i]}\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:${SITES[$i]}\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth") \
+        2>/dev/null
+
+      # check exit code
+      if [ $? -ne 0 ]; then
+        echo "❌ Error generating ssl certs for ${SITES[$i]}"
+        exit 1
+      fi
+
       # If key file exists, change the name of it.
       if [ -f key.pem ]; then
         mv key.pem "../ssl-certs/${SITES[$i]}-key.pem"


### PR DESCRIPTION
This upgrades the cert error to `NET::ERR_CERT_AUTHORITY_INVALID` which has a prompt to proceed through.
![Screen Shot 2022-08-12 at 1 50 24 PM](https://user-images.githubusercontent.com/3294460/184443122-914cdec4-d618-4f7b-88e3-48786657d931.png)



Also, added check for exit code of `openssl` since output is piped to dev/null.
![Screen Shot 2022-08-12 at 1 13 56 PM](https://user-images.githubusercontent.com/3294460/184443176-cc28e72e-547b-4a75-bfb1-05d58dfe2483.png)
